### PR TITLE
Add delay for task creation after file create to allow plugins like templater to populate the new file.

### DIFF
--- a/Taskido/view.js
+++ b/Taskido/view.js
@@ -358,10 +358,11 @@ function setEvents() {
 				if (abstractFilePath) {
 					app.vault.read(abstractFilePath).then(function(fileText) {
 						app.vault.modify(abstractFilePath, addNewTask(fileText, newTask));
-						new Notice("New task saved!")
+						new Notice("New task saved!");
 					});
 				} else {
-					app.fileManager.createNewMarkdownFile(app.vault.getRoot(), filePath.slice(0, -3))
+					console.log(filePath.replace(/\.[^/.]+$/, ""));
+					app.fileManager.createNewMarkdownFile(app.vault.getRoot(), filePath.replace(/\.[^/.]+$/, ""))
 						.then(function (newFile) {
 							/**
 							 * start timer to allow plugins (like templater) to populate the text in the new file
@@ -369,13 +370,13 @@ function setEvents() {
 							setTimeout(function () {
 								app.vault.read(newFile).then(function(fileText) {
 									app.vault.modify(newFile, addNewTask(fileText, newTask));
-									new Notice("New task saved!")
+									new Notice("New task saved!");
 								});
 							}, WAIT_AFTER_CREATION_FOR_TEMPLATES_MS);
 						});				
 				}
 				rootNode.querySelector('.newTask').value = "";
-				rootNode.querySelector('.newTask').blur();
+				rootNode.querySelector('.newTask').focus();
 			} catch(err) {
 				new Notice("Something went wrong!");
 			};

--- a/Taskido/view.js
+++ b/Taskido/view.js
@@ -1,5 +1,7 @@
 let {pages, inbox, select, taskOrder, taskFiles, globalTaskFilter, dailyNoteFolder, dailyNoteFormat, done, sort, css, forward, dateFormat, options, section} = input;
 
+const WAIT_AFTER_CREATION_FOR_TEMPLATES_MS = 1000;
+
 // Error Handling
 if (!pages && pages!="") { dv.span('> [!ERROR] Missing pages parameter\n> \n> Please set the pages parameter like\n> \n> `pages: ""`'); return false };
 if (dailyNoteFormat) { if (dailyNoteFormat.match(/[|\\YMDWwd.,-: \[\]]/g).length != dailyNoteFormat.length) { dv.span('> [!ERROR] The `dailyNoteFormat` contains invalid characters'); return false }};
@@ -356,13 +358,24 @@ function setEvents() {
 				if (abstractFilePath) {
 					app.vault.read(abstractFilePath).then(function(fileText) {
 						app.vault.modify(abstractFilePath, addNewTask(fileText, newTask));
+						new Notice("New task saved!")
 					});
 				} else {
-					app.vault.create(filePath, "- [ ] " + newTask);
-				};
-				new Notice("New task saved!");
+					app.fileManager.createNewMarkdownFile(app.vault.getRoot(), filePath.slice(0, -3))
+						.then(function (newFile) {
+							/**
+							 * start timer to allow plugins (like templater) to populate the text in the new file
+							 */
+							setTimeout(function () {
+								app.vault.read(newFile).then(function(fileText) {
+									app.vault.modify(newFile, addNewTask(fileText, newTask));
+									new Notice("New task saved!")
+								});
+							}, WAIT_AFTER_CREATION_FOR_TEMPLATES_MS);
+						});				
+				}
 				rootNode.querySelector('.newTask').value = "";
-				rootNode.querySelector('.newTask').focus();
+				rootNode.querySelector('.newTask').blur();
 			} catch(err) {
 				new Notice("Something went wrong!");
 			};


### PR DESCRIPTION
This change is useful for those who use [Templater](https://github.com/SilentVoid13/Templater) plugin. 

I use templater for my daily notes.  Currently, when a task is added in the tasks timeline and the file does not exist, the generated file does not contain the template.  

I made some changes, so that:
- initially an empty file is generated,
- a timeout is set so that the Templater plugin populates the file , and then
- the new task is added to the file

The timeout is currently a constant in the script (1 second ; 500 ms were not enough in my  machine for the Templater to kick in), but it could be defined as a parameter.