### PR TITLE
force details.today view to use background color

### DIFF
--- a/Taskido/view.css
+++ b/Taskido/view.css
@@ -38,6 +38,7 @@
 }
 .taskido .details.today {
 	padding: 30px 0;
+	background-color: var(--background-primary) !important;
 }
 .taskido .counters {
 	display: flex;


### PR DESCRIPTION
fix for conflict when using [day planner](https://github.com/ivan-lednev/obsidian-day-planner) plugin, which would make .details.today use accent color. 

Forcing the obsidian background primary style would fix this problem